### PR TITLE
Applying RPI patch as proposed in its forums

### DIFF
--- a/omx/gstomxvideoenc.c
+++ b/omx/gstomxvideoenc.c
@@ -1353,13 +1353,14 @@ gst_omx_video_enc_handle_output_frame (GstOMXVideoEnc * self, GstOMXPort * port,
 
       outbuf = gst_buffer_new_and_alloc (gst_buffer_get_size(frame->output_buffer) + buf->omx_buf->nFilledLen);
 
+      gst_buffer_map (outbuf, &map, GST_MAP_WRITE);
+
       gst_buffer_map (frame->output_buffer, &map_fragment, GST_MAP_READ);
       memcpy(map.data,
              map_fragment.data,
              gst_buffer_get_size(frame->output_buffer));
       gst_buffer_unmap (frame->output_buffer, &map_fragment);
 
-      gst_buffer_map (outbuf, &map, GST_MAP_WRITE);
       memcpy (map.data + gst_buffer_get_size(frame->output_buffer),
           buf->omx_buf->pBuffer + buf->omx_buf->nOffset,
           buf->omx_buf->nFilledLen);


### PR DESCRIPTION
The complete explanation is in this thread
https://www.raspberrypi.org/forums/viewtopic.php?t=200306

The fix proposed here https://www.raspberrypi.org/forums/viewtopic.php?t=200306&start=25#p1260138 fixes a problem with raspberry using omxh264enc plugin which tries to forward partial buffers into the pipeline.

This patch was proposed a year ago in 1.10 I've just adapted to the latest version

I guess raspbian maintainers might have their fork somewhere but I haven't found it.